### PR TITLE
Translations, container elements, Webform settings, source entity, states

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,3 +220,24 @@ When you get the fid (e.g. 1910) you then update the `$values` variable with it:
     {
       "values": "{\"webform_id\":\"contact\",\"subject\":\"This is the subject\",\"message\":\"Hey, I have a question\",\"date_of_birth\":\"05\/01\/1991\",\"email\":\"email@example.com\",\"upload_your_file\":\"1910\"}"
     }
+
+### Create a webform submission with a source entity
+If the webform supports a source entity, you can pass in the variables with the
+data, the same as with `webform_id`. For example, if your webform's URL is:
+`/form/my-form?source_entity_id=123&source_entity_type=node`
+
+Pass the following JSON encoded values:
+
+```
+{
+    "webform_id": "my_form",
+    "source_entity_id": "123",
+    "source_entity_type": "node",
+    "subject":"This is the subject",
+    "message":"Hey, I have a question",
+    "date_of_birth":"05/01/1930",
+    "email":"email@example.com"
+  }
+```
+
+The mutation will automatically pass these values to the webform submission.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ composer require drupal/graphql_webform
  - Webform Entity Select
  - Number
  - Composite (with the above items supported)
+ - Time
 
 ## Retrieve webform elements
 

--- a/modules/graphql_webform_states/graphql_webform_states.info.yml
+++ b/modules/graphql_webform_states/graphql_webform_states.info.yml
@@ -1,0 +1,10 @@
+name: 'GraphQL Webform States'
+type: module
+description: 'Provides GraphQL integration for webform element states.'
+core: 8.x
+core_version_requirement: ^8 || ^9
+package: 'GraphQL'
+dependencies:
+  - drupal:webform
+  - drupal:graphql
+  - drupal:graphql_webform

--- a/modules/graphql_webform_states/src/Plugin/Deriver/WebformStatesDeriver.php
+++ b/modules/graphql_webform_states/src/Plugin/Deriver/WebformStatesDeriver.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\Deriver;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\graphql\Utility\StringHelper;
+
+/**
+ * Deriver for webform element states.
+ */
+class WebformStatesDeriver extends DeriverBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($basePluginDefinition) {
+    $fields = [
+      'visible',
+      'invisible',
+      'visible_slide',
+      'invisible_slide',
+      'enabled',
+      'disabled',
+      'readwrite',
+      'readonly',
+      'expanded',
+      'collapsed',
+      'required',
+      'optional',
+      'checked',
+      'unchecked',
+    ];
+
+    foreach ($fields as $field) {
+      $derivative = [
+        'id' => $field,
+        'name' => StringHelper::propCase($field),
+        'type' => 'WebformElementState',
+        'parents' => ['WebformElementStates'],
+      ] + $basePluginDefinition;
+      $this->derivatives[$field] = $derivative;
+    }
+    return parent::getDerivativeDefinitions($basePluginDefinition);
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Enums/WebformStateConditionTrigger.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Enums/WebformStateConditionTrigger.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Enums;
+
+use Drupal\graphql\Plugin\GraphQL\Enums\EnumPluginBase;
+
+/**
+ * Webform element state condition triggers.
+ *
+ * @GraphQLEnum(
+ *   id = "webform_state_condition_trigger",
+ *   name = "WebformStateConditionTrigger",
+ *   values = {
+ *     "EMPTY" = "empty",
+ *     "FILLED" = "filled",
+ *     "CHECKED" = "checked",
+ *     "UNCHECKED" = "unchecked",
+ *     "VALUE_IS" = "value",
+ *     "VALUE_IS_NOT" = "!value",
+ *     "PATTERN" = "pattern",
+ *     "NOT_PATTERN" = "!pattern",
+ *     "LESS_THAN" = "less",
+ *     "LESS_THAN_EQUAL_TO" = "less_equal",
+ *     "GREATER_THAN" = "greater",
+ *     "GREATER_THAN_EQUAL_TO" = "greater_equal",
+ *     "BETWEEN" = "between",
+ *     "NOT_BETWEEN" = "!between",
+ *   }
+ * )
+ */
+class WebformStateConditionTrigger extends EnumPluginBase {
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Enums/WebformStateLogic.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Enums/WebformStateLogic.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Enums;
+
+use Drupal\graphql\Plugin\GraphQL\Enums\EnumPluginBase;
+
+/**
+ * Webform state logic options.
+ *
+ * @GraphQLEnum(
+ *   id = "webform_state_logic",
+ *   name = "WebformStateLogic",
+ *   values = {
+ *     "AND" = "and",
+ *     "XOR" = "xor",
+ *     "OR" = "or",
+ *   }
+ * )
+ */
+class WebformStateLogic extends EnumPluginBase {
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionField.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionField.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * The field (aka element ID) the condition is referencing.
+ *
+ * @GraphQLField(
+ *   id = "webform_element_state_condition_field",
+ *   parents = {"WebformElementStateCondition"},
+ *   name = "field",
+ *   type = "String",
+ * )
+ */
+class ConditionField extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    $selector = $value['selector'] ?? '';
+    $matches = [];
+    preg_match('/:input\[name="(.*?)["[]/', $selector, $matches);
+    yield $matches[1] ?? NULL;
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionFieldValue.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionFieldValue.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * The actual value that the field (element ID) must be validated against.
+ *
+ * The value is derived from the selector and falls back to the value defined
+ * by webform. For example, if the condition is triggered against a checkbox of
+ * a multiple checkbox element, the fieldValue will resolve to the value of
+ * this checkbox. The selector might look like this:
+ *
+ * :input[name="select_topics[checkboxes][Security]"]
+ *
+ * That means that fieldValue should be "Security", so that we can validate
+ * against the field "select_topics" if the trigger is VALUE_IS.
+ *
+ * @GraphQLField(
+ *   id = "webform_element_state_condition_field_value",
+ *   parents = {"WebformElementStateCondition"},
+ *   name = "fieldValue",
+ *   type = "String",
+ * )
+ */
+class ConditionFieldValue extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    $condition_value = $value['value'] ?? '';
+    $selector = $value['selector'] ?? '';
+    $matches = [];
+    preg_match('/:input\[name=".*\[(.*)]"/', $selector, $matches);
+
+    yield $matches[1] ?? $condition_value;
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionSelector.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionSelector.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * The selector of the condition.
+ *
+ * @GraphQLField(
+ *   id = "webform_element_state_condition_selector",
+ *   parents = {"WebformElementStateCondition"},
+ *   name = "selector",
+ *   type = "String",
+ * )
+ */
+class ConditionSelector extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    yield $value['selector'] ?? '';
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionTrigger.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionTrigger.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * The trigger of the condition.
+ *
+ * @GraphQLField(
+ *   id = "webform_element_state_condition_trigger",
+ *   parents = {"WebformElementStateCondition"},
+ *   name = "trigger",
+ *   type = "WebformStateConditionTrigger",
+ * )
+ */
+class ConditionTrigger extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    yield $value['trigger'] ?? NULL;
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionValue.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/ConditionValue.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * The value of the condition.
+ *
+ * Note that this is the raw value specified by webform, which might not be the
+ * expected value.
+ *
+ * For example, if a condition is made against a single checkbox of a multiple
+ * checkbox element, then the value returned here will be '1', because the
+ * desired checkbox is defined in the selector.
+ *
+ * Use 'fieldValue' to get the expected value.
+ *
+ * @GraphQLField(
+ *   id = "webform_element_state_condition_value",
+ *   parents = {"WebformElementStateCondition"},
+ *   name = "value",
+ *   type = "String",
+ * )
+ */
+class ConditionValue extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    yield $value['value'] ?? '';
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/StateConditions.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/StateConditions.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * The conditions of a element state.
+ *
+ * @GraphQLField(
+ *   id = "webform_element_state_conditions",
+ *   parents = {"WebformElementState"},
+ *   name = "conditions",
+ *   type = "[WebformElementStateCondition]",
+ * )
+ */
+class StateConditions extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    $conditions = $value['conditions'] ?? [];
+
+    foreach ($conditions as $condition) {
+      yield $condition;
+    }
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/StateLogic.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/StateLogic.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * The logic operator of a element state.
+ *
+ * @GraphQLField(
+ *   id = "webform_element_state_logic",
+ *   parents = {"WebformElementState"},
+ *   name = "logic",
+ *   type = "WebformStateLogic",
+ * )
+ */
+class StateLogic extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    yield $value['logic'];
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/WebformElementState.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/WebformElementState.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use Drupal\webform\Utility\WebformArrayHelper;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Get the logic and conditions of a webform element state.
+ *
+ * @GraphQLField(
+ *   id = "webform_element_state",
+ *   parents = {"WebformElementStates"},
+ *   deriver = "Drupal\graphql_webform_states\Plugin\Deriver\WebformStatesDeriver",
+ * )
+ */
+class WebformElementState extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    $definition = $this->getPluginDefinition();
+    $field = str_replace('_', '-', $definition['id']);
+    $state = $value[$field] ?? NULL;
+
+    if ($state) {
+      $logic = $this->getConditionLogic($state);
+      $conditions = $this->getConditions($state);
+
+      if (!empty($conditions)) {
+        yield [
+          'logic' => $logic,
+          'conditions' => $conditions,
+        ];
+      }
+    }
+  }
+
+  /**
+   * Determine the condition logic.
+   *
+   * @param array $conditions
+   *   The webform conditions array.
+   *
+   * @return string
+   *   The logic.
+   */
+  private function getConditionLogic($conditions) {
+    if ($conditions && WebformArrayHelper::isSequential($conditions)) {
+      return (in_array('xor', $conditions)) ? 'xor' : 'or';
+    }
+
+    return 'and';
+  }
+
+  /**
+   * Map the conditions.
+   *
+   * The conditions can either be an array with selectors as keys or a
+   * sequential array that contains both conditions and strings indicating the
+   * logic ('or', 'and', 'xor').
+   *
+   * @param array $definition
+   *   The conditions array from the webform element.
+   *
+   * @return array
+   *   The mapped, sequential array of conditions.
+   */
+  private function getConditions($definition) {
+    if (!$definition) {
+      return [];
+    }
+
+    $conditions = [];
+
+    foreach ($definition as $index => $value) {
+      // Skip and, or, and xor.
+      if (is_string($value) && in_array($value, ['and', 'or', 'xor'])) {
+        continue;
+      }
+
+      $selector = NULL;
+      $condition = NULL;
+
+      if (is_int($index)) {
+        $selector = key($value);
+        $condition = $value[$selector];
+      }
+      else {
+        $selector = $index;
+        $condition = $value;
+      }
+
+      $conditions[] = [
+        'selector' => $selector,
+        'trigger' => array_key_first($condition),
+        'value' => (string) array_values($condition)[0],
+      ];
+    }
+
+    return $conditions;
+  }
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/WebformElementState.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/WebformElementState.php
@@ -50,7 +50,12 @@ class WebformElementState extends FieldPluginBase {
    */
   private function getConditionLogic($conditions) {
     if ($conditions && WebformArrayHelper::isSequential($conditions)) {
-      return (in_array('xor', $conditions)) ? 'xor' : 'or';
+      if (in_array('xor', $conditions)) {
+        return 'xor';
+      }
+      else if (in_array('or', $conditions)) {
+        return 'or';
+      }
     }
 
     return 'and';

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/WebformElementStates.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Fields/WebformElementStates.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Fields;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * Resolve states of a webform element.
+ *
+ * @GraphQLField(
+ *   secure = true,
+ *   parents = {"WebformElement"},
+ *   id = "webform_element_states",
+ *   name = "states",
+ *   type = "WebformElementStates",
+ * )
+ */
+class WebformElementStates extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    yield $value['#states'] ?? NULL;
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Types/WebformElementState.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Types/WebformElementState.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A webform element state.
+ *
+ * @GraphQLType(
+ *   id = "webform_element_state",
+ *   name = "WebformElementState",
+ * )
+ */
+class WebformElementState extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return TRUE;
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Types/WebformElementStateCondition.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Types/WebformElementStateCondition.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A Webform element state condition.
+ *
+ * @GraphQLType(
+ *   id = "webform_element_state_condition",
+ *   name = "WebformElementStateCondition",
+ * )
+ */
+class WebformElementStateCondition extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return isset($object['selector']) && isset($object['trigger']);
+  }
+
+}

--- a/modules/graphql_webform_states/src/Plugin/GraphQL/Types/WebformElementStates.php
+++ b/modules/graphql_webform_states/src/Plugin/GraphQL/Types/WebformElementStates.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\graphql_webform_states\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * States of a webform element.
+ *
+ * @GraphQLType(
+ *   id = "webform_element_states",
+ *   name = "WebformElementStates",
+ * )
+ */
+class WebformElementStates extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return TRUE;
+  }
+
+}

--- a/src/Plugin/Deriver/WebformSettingsDeriver.php
+++ b/src/Plugin/Deriver/WebformSettingsDeriver.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\Deriver;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\graphql\Utility\StringHelper;
+use Drupal\webform\Entity\Webform;
+
+/**
+ * Deriver for webform settings.
+ *
+ * The default settings of the Webform entity are used to derive possible
+ * settings fields.
+ */
+class WebformSettingsDeriver extends DeriverBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($basePluginDefinition) {
+    $default_settings = Webform::getDefaultSettings();
+
+    // Some settings have a default value of NULL, so we need to map these
+    // manually.
+    $null_settings = [
+      'ajax_speed' => 'Int',
+      'limit_total' => 'Int',
+      'limit_total_interval' => 'Int',
+      'limit_user' => 'Int',
+      'limit_user_interval' => 'Int',
+      'entity_limit_total' => 'Int',
+      'entity_limit_total_interval' => 'Int',
+      'entity_limit_user' => 'Int',
+      'entity_limit_user_interval' => 'Int',
+      'purge_days' => 'Int',
+    ];
+
+    foreach ($default_settings as $prop => $value) {
+      $type = $null_settings[$prop] ?? $this->getType($value);
+      if ($type) {
+        $derivative = [
+          'id' => $prop,
+          'name' => StringHelper::propCase($prop),
+          'type' => $type,
+          'parents' => ['WebformSettings'],
+        ] + $basePluginDefinition;
+        $this->derivatives[$prop] = $derivative;
+      }
+    }
+    return parent::getDerivativeDefinitions($basePluginDefinition);
+  }
+
+  /**
+   * Get the GraphQL type for a PHP type.
+   *
+   * @var mixed $value
+   *   The value to get the type for.
+   *
+   * @return string|null
+   *   The GraphQL type.
+   */
+  private function getType($value) {
+    switch (gettype($value)) {
+      case 'boolean':
+        return 'Boolean';
+      case 'integer':
+        return 'Int';
+      case 'double':
+        return 'Float';
+      case 'string':
+        return 'String';
+    }
+
+    return NULL;
+  }
+}

--- a/src/Plugin/GraphQL/Fields/Element/WebformElementDescription.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElementDescription.php
@@ -17,7 +17,8 @@ use GraphQL\Type\Definition\ResolveInfo;
  *     "WebformElementManagedFileBase",
  *     "WebformElementDateBase",
  *     "WebformElementComposite",
- *     "WebformElementNumber"
+ *     "WebformElementNumber",
+ *     "WebformElementCheckbox",
  *   },
  *   id = "webform_element_description",
  *   name = "description",

--- a/src/Plugin/GraphQL/Fields/Element/WebformElementMarkup.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElementMarkup.php
@@ -23,7 +23,7 @@ class WebformElementMarkup extends FieldPluginBase {
    * {@inheritdoc}
    */
   public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
-    yield $value['#markup'] ?? '';
+    yield $value['#markup'] ?? $value['#text'] ?? '';
   }
 
 }

--- a/src/Plugin/GraphQL/Fields/Element/WebformElementMarkup.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElementMarkup.php
@@ -23,7 +23,7 @@ class WebformElementMarkup extends FieldPluginBase {
    * {@inheritdoc}
    */
   public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
-    yield $value['#markup'];
+    yield $value['#markup'] ?? '';
   }
 
 }

--- a/src/Plugin/GraphQL/Fields/Element/WebformElementOptions.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElementOptions.php
@@ -6,7 +6,6 @@ use Drupal\graphql\GraphQL\Execution\ResolveContext;
 use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
 use Drupal\webform\Element\WebformEntitySelect;
 use Drupal\webform\Entity\WebformOptions;
-use Drupal\webform\Plugin\WebformElement\Select;
 use GraphQL\Type\Definition\ResolveInfo;
 use Drupal\webform\Element\WebformTermSelect;
 use Drupal\webform\Plugin\WebformElement\WebformTermSelect as WebformTermSelectPlugin;
@@ -34,12 +33,14 @@ class WebformElementOptions extends FieldPluginBase {
       return;
     }
 
+    $plugin = $value['plugin'];
+
     if (!isset($value['#options'])) {
       $value['#options'] = [];
 
-      if ($value['plugin'] instanceof WebformTermSelectPlugin) {
+      if ($plugin instanceof WebformTermSelectPlugin) {
         if (!isset($value['#vocabulary'])) {
-          $element_info = $value['plugin']->getInfo();
+          $element_info = $plugin->getInfo();
           $value['#vocabulary'] = isset($element_info['#vocabulary']) ? $element_info['#vocabulary'] : '';
         }
 
@@ -47,13 +48,13 @@ class WebformElementOptions extends FieldPluginBase {
           WebformTermSelect::setOptions($value);
         }
       }
-      elseif ($value['plugin'] instanceof WebformEntitySelectPlugin) {
+      elseif ($plugin instanceof WebformEntitySelectPlugin) {
         WebformEntitySelect::setOptions($value);
       }
     }
     else {
       // Handle predefined options.
-      if (is_string($value['#options']) && $value['plugin'] instanceof Select) {
+      if (is_string($value['#options'])) {
         $value['#options'] = WebformOptions::getElementOptions($value);
       }
     }

--- a/src/Plugin/GraphQL/Fields/Element/WebformElementRequired.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElementRequired.php
@@ -16,7 +16,8 @@ use GraphQL\Type\Definition\ResolveInfo;
  *     "WebformElementDateBase",
  *     "WebformElementOptionsBase",
  *     "WebformElementManagedFileBase",
- *     "WebformElementNumber"
+ *     "WebformElementNumber",
+ *     "WebformElementCheckbox",
  *   },
  *   id = "webform_element_required",
  *   name = "required",

--- a/src/Plugin/GraphQL/Fields/Element/WebformElementRequired.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElementRequired.php
@@ -18,6 +18,7 @@ use GraphQL\Type\Definition\ResolveInfo;
  *     "WebformElementManagedFileBase",
  *     "WebformElementNumber",
  *     "WebformElementCheckbox",
+ *     "WebformElementTimeBase",
  *   },
  *   id = "webform_element_required",
  *   name = "required",

--- a/src/Plugin/GraphQL/Fields/Element/WebformElementTitle.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElementTitle.php
@@ -18,7 +18,9 @@ use GraphQL\Type\Definition\ResolveInfo;
  *     "WebformElementManagedFileBase",
  *     "WebformElementDateBase",
  *     "WebformElementComposite",
- *     "WebformElementNumber"
+ *     "WebformElementNumber",
+ *     "WebformElementSection",
+ *     "WebformElementCheckbox",
  *   },
  *   id = "webform_element_title",
  *   name = "title",
@@ -31,7 +33,7 @@ class WebformElementTitle extends FieldPluginBase {
    * {@inheritdoc}
    */
   public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
-    yield $value['#title'];
+    yield $value['#title'] ?? '';
   }
 
 }

--- a/src/Plugin/GraphQL/Fields/Element/WebformElementTitle.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElementTitle.php
@@ -21,6 +21,7 @@ use GraphQL\Type\Definition\ResolveInfo;
  *     "WebformElementNumber",
  *     "WebformElementSection",
  *     "WebformElementCheckbox",
+ *     "WebformElementTimeBase",
  *   },
  *   id = "webform_element_title",
  *   name = "title",

--- a/src/Plugin/GraphQL/Fields/Element/WebformElements.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElements.php
@@ -17,6 +17,7 @@ use GraphQL\Type\Definition\ResolveInfo;
  *     "Webform",
  *     "WebformElementComposite",
  *     "WebformElementSection",
+ *     "WebformElementContainer",
  *     "WebformElementFlexbox"
  *   },
  *   id = "webform_elements",

--- a/src/Plugin/GraphQL/Fields/Element/WebformElements.php
+++ b/src/Plugin/GraphQL/Fields/Element/WebformElements.php
@@ -67,6 +67,8 @@ class WebformElements extends FieldPluginBase {
    */
   private function getElements($value) {
     if ($value instanceof Webform) {
+      $elements = $value->getElementsDecoded();
+      $value->applyVariants(NULL, $elements);
       return $value->getElementsDecoded();
     }
 

--- a/src/Plugin/GraphQL/Fields/Settings/WebformSettingBase.php
+++ b/src/Plugin/GraphQL/Fields/Settings/WebformSettingBase.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Fields\Settings;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A GraphQL field for webform settings.
+ *
+ * @GraphQLField(
+ *   id = "webform_setting_base",
+ *   parents = {"WebformSettings"},
+ *   deriver = "Drupal\graphql_webform\Plugin\Deriver\WebformSettingsDeriver",
+ * )
+ */
+class WebformSettingBase extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    $definition = $this->getPluginDefinition();
+    $field = $definition['id'];
+    yield $value[$field] ?? NULL;
+  }
+
+}

--- a/src/Plugin/GraphQL/Fields/Settings/WebformSettings.php
+++ b/src/Plugin/GraphQL/Fields/Settings/WebformSettings.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Fields\Settings;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Fields\FieldPluginBase;
+use Drupal\webform\Entity\Webform;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A GraphQL field for getting the webform settings.
+ *
+ * @GraphQLField(
+ *   secure = true,
+ *   parents = {"Webform"},
+ *   id = "webform_settings",
+ *   name = "settings",
+ *   type = "WebformSettings",
+ * )
+ */
+class WebformSettings extends FieldPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function resolveValues($value, array $args, ResolveContext $context, ResolveInfo $info) {
+    if ($value instanceof Webform) {
+      yield $value->getSettings();
+    }
+  }
+
+}

--- a/src/Plugin/GraphQL/Interfaces/WebformElementTimeBase.php
+++ b/src/Plugin/GraphQL/Interfaces/WebformElementTimeBase.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Interfaces;
+
+use Drupal\graphql\Plugin\GraphQL\Interfaces\InterfacePluginBase;
+
+/**
+ * GraphQL interface for Time form elements.
+ *
+ * @GraphQLInterface(
+ *   id = "webform_element_time_base",
+ *   name = "WebformElementTimeBase",
+ *   description = @Translation(""),
+ *   interfaces = {"WebformElement"}
+ * )
+ */
+class WebformElementTimeBase extends InterfacePluginBase {
+
+}

--- a/src/Plugin/GraphQL/Mutations/SubmitForm.php
+++ b/src/Plugin/GraphQL/Mutations/SubmitForm.php
@@ -103,6 +103,12 @@ class SubmitForm extends MutationPluginBase implements ContainerFactoryPluginInt
     $result = $this->renderer->executeInRenderContext($renderContext, function () use ($values) {
       $webform_data['webform_id'] = $values['webform_id'];
       unset($values['webform_id']);
+      if (!empty($values['source_entity_id']) && !empty($values['source_entity_type'])) {
+        $webform_data['entity_id'] = $values['source_entity_id'];
+        $webform_data['entity_type'] = $values['source_entity_type'];
+        unset($values['source_entity_id']);
+        unset($values['source_entity_type']);
+      }
       $webform_data['data'] = $values;
 
       // Validate submission.

--- a/src/Plugin/GraphQL/Types/Settings/WebformSettings.php
+++ b/src/Plugin/GraphQL/Types/Settings/WebformSettings.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Types\Settings;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A GraphQL type for webform settings.
+ *
+ * @GraphQLType(
+ *   id = "webform_confirmation_type",
+ *   name = "WebformSettings",
+ *   weight = -999
+ * )
+ */
+class WebformSettings extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return isset($object['confirmation_type']);
+  }
+
+}

--- a/src/Plugin/GraphQL/Types/WebformElementCheckbox.php
+++ b/src/Plugin/GraphQL/Types/WebformElementCheckbox.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use Drupal\webform\Plugin\WebformElement\Checkbox;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A GraphQL type for checkbox form item.
+ *
+ * @GraphQLType(
+ *   id = "webform_element_checkbox",
+ *   name = "WebformElementCheckbox",
+ *   interfaces = {"WebformElement"},
+ * )
+ */
+class WebformElementCheckbox extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return $object['plugin'] instanceof Checkbox;
+  }
+
+}

--- a/src/Plugin/GraphQL/Types/WebformElementContainer.php
+++ b/src/Plugin/GraphQL/Types/WebformElementContainer.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use Drupal\webform\Plugin\WebformElement\Container;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A GraphQL type for container form items.
+ *
+ * @GraphQLType(
+ *   id = "webform_element_container",
+ *   name = "WebformElementContainer",
+ *   interfaces = {"WebformElement"}
+ * )
+ */
+class WebformElementContainer extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return $object['plugin'] instanceof Container;
+  }
+
+}

--- a/src/Plugin/GraphQL/Types/WebformElementFlexbox.php
+++ b/src/Plugin/GraphQL/Types/WebformElementFlexbox.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use Drupal\webform\Plugin\WebformElement\WebformFlexbox;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A GraphQL type for flexbox elements.
+ *
+ * @GraphQLType(
+ *   id = "webform_element_flexbox",
+ *   name = "WebformElementFlexbox",
+ *   interfaces = {"WebformElement"}
+ * )
+ */
+class WebformElementFlexbox extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return $object['plugin'] instanceof WebformFlexbox;
+  }
+
+}

--- a/src/Plugin/GraphQL/Types/WebformElementSection.php
+++ b/src/Plugin/GraphQL/Types/WebformElementSection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use Drupal\webform\Plugin\WebformElement\WebformSection;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A GraphQL type for section form items.
+ *
+ * @GraphQLType(
+ *   id = "webform_element_section",
+ *   name = "WebformElementSection",
+ *   interfaces = {"WebformElement"}
+ * )
+ */
+class WebformElementSection extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return $object['plugin'] instanceof WebformSection;
+  }
+
+}

--- a/src/Plugin/GraphQL/Types/WebformElementTime.php
+++ b/src/Plugin/GraphQL/Types/WebformElementTime.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\graphql_webform\Plugin\GraphQL\Types;
+
+use Drupal\graphql\GraphQL\Execution\ResolveContext;
+use Drupal\graphql\Plugin\GraphQL\Types\TypePluginBase;
+use Drupal\webform\Plugin\WebformElement\WebformTime;
+use GraphQL\Type\Definition\ResolveInfo;
+
+/**
+ * A GraphQL type for date form item.
+ *
+ * @GraphQLType(
+ *   id = "webform_element_time",
+ *   name = "WebformElementTime",
+ *   interfaces = {"WebformElement"},
+ * )
+ */
+class WebformElementTime extends TypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($object, ResolveContext $context, ResolveInfo $info) {
+    return $object['plugin'] instanceof WebformTime;
+  }
+
+}

--- a/src/Plugin/GraphQL/Types/WebformElementTime.php
+++ b/src/Plugin/GraphQL/Types/WebformElementTime.php
@@ -13,7 +13,7 @@ use GraphQL\Type\Definition\ResolveInfo;
  * @GraphQLType(
  *   id = "webform_element_time",
  *   name = "WebformElementTime",
- *   interfaces = {"WebformElement"},
+ *   interfaces = {"WebformElementTimeBase"},
  * )
  */
 class WebformElementTime extends TypePluginBase {


### PR DESCRIPTION
### Translated webform elements

Elements returned are now translated.

### Section, container and flexbox elements

In addition to the composite element, three new "container" type elements are supported.

### Checkbox element

In addition to the existing checkboxes element, support for a single checkbox element is added.

### Webform settings

A new field on the Webform type allows accessing most of the settings of a webform. Currently only settings that resolve to a Int, Boolean, Float or String are resolved.

```graphql
query webform {
  webformById(webform_id: "my_form") {
    title
    settings {
      confirmationType
      confirmationTitle
      confirmationMessage
      confirmationUrl
      formPrepopulateSourceEntity
    }
  }
}
```

### Support for source entity

Added support for providing a source_entity_id and source_entity_type key in the mutation.

### Support for element states

A new submodule that adds support for all element states (visibility, readonly, etc.) and condition triggers (e.g. filled, value_is, between). Two fields (field and fieldValue) provide additional values missing from the default webform element definition that make it easier to implement state logic in the frontend. `field` returns the ID of the webform element that the condition is referencing and `fieldValue` contains the actual value that is validated for the `field` when submitting.

Example query:

```graphql
query webform {
  webformById(webform_id: "foobar") {
    elements {
      states {
        visible {
          logic
          conditions {
            selector
            trigger
            field
            fieldValue
          }
        }
      }
    }
  }
}
```

Will return:

```json
{
  "data": {
    "webformById": {
      "title": "Foobar",
      "elements": [
        {
          "__typename": "WebformElementCheckboxes",
          "type": "webform_checkboxes_other",
          "states": {
            "visible": {
              "logic": "AND",
              "conditions": [
                {
                  "selector": ":input[name=\"newsletter\"]",
                  "trigger": "VALUE_IS",
                  "field": "newsletter",
                  "fieldValue": "yes"
                },
                {
                  "selector": ":input[name=\"newsletter_topics[checkboxes][Security]\"]",
                  "trigger": "FILLED",
                  "field": "newsletter_topics",
                  "fieldValue": "Security"
                }
              ]
            }
          }
        }
      ]
    }
  }
}
```